### PR TITLE
fix(routes): rename LogerProfile relationships route to avoid name collision

### DIFF
--- a/app/Domains/LogerProfile/Http/Controllers/LogerProfileController.php
+++ b/app/Domains/LogerProfile/Http/Controllers/LogerProfileController.php
@@ -2,12 +2,12 @@
 
 namespace App\Domains\LogerProfile\Http\Controllers;
 
-use Exception;
-use App\Http\Controllers\Controller;
 use App\Domains\LogerProfile\Data\LogerProfileData;
-use App\Http\Controllers\Traits\HasEnrichedRequest;
 use App\Domains\LogerProfile\Exceptions\ProfileNotFound;
 use App\Domains\LogerProfile\Services\LogerProfileService;
+use App\Http\Controllers\Controller;
+use App\Http\Controllers\Traits\HasEnrichedRequest;
+use Exception;
 
 class LogerProfileController extends Controller
 {
@@ -53,25 +53,27 @@ class LogerProfileController extends Controller
     {
         try {
             $profile = $profileService->getByName(request()->user()->current_team_id, $profileName);
+
             return inertia('Relationships/RelationshipView', [
                 'profile' => $profile,
-                'entities' => fn () =>  $profileService->getEntitiesByProfileId($profile->id),
+                'entities' => fn () => $profileService->getEntitiesByProfileId($profile->id),
             ]);
         } catch (Exception $e) {
             if ($e instanceof ProfileNotFound) {
-               return to_route("relationships-overview");
+                return to_route('relationships-overview');
             }
         }
     }
 
     public function overview(LogerProfileService $profileService)
     {
-        $profileName = "partner";
+        $profileName = 'partner';
         $profile = $profileService->checkByName(request()->user()->current_team_id, $profileName);
 
         if ($profile) {
-            to_route("relationships.index", [ "profileName" => $profileName]);
+            to_route('relationships.profile', ['profileName' => $profileName]);
         }
+
         return inertia('Relationships/NotFound', [
             'profiles' => [],
         ]);

--- a/app/Domains/LogerProfile/routes.php
+++ b/app/Domains/LogerProfile/routes.php
@@ -1,8 +1,8 @@
 <?php
 
-use Illuminate\Support\Facades\Route;
 use App\Domains\LogerProfile\Http\Controllers\LogerProfileController;
 use App\Domains\LogerProfile\Http\Controllers\LogerProfileEntityController;
+use Illuminate\Support\Facades\Route;
 
 Route::middleware(['auth:sanctum', 'atmosphere.teamed', 'verified', 'loger.concerns:profiles'])->group(function () {
     // Route::resource('/loger-profiles', [LogerProfileController::class, 'index'])->name('profiles.index');
@@ -10,7 +10,7 @@ Route::middleware(['auth:sanctum', 'atmosphere.teamed', 'verified', 'loger.conce
     Route::resource('/loger-profiles/{profileId}/entities', LogerProfileEntityController::class);
     Route::get('/loger-profiles/{profileId}/transactions', [LogerProfileController::class, 'transactions']);
     Route::get('/relationships/overview', [LogerProfileController::class, 'overview'])->name('relationships-overview');
-    Route::get('/relationships/{profileName}', [LogerProfileController::class, 'relationships'])->name("relationships.index");
+    Route::get('/relationships/{profileName}', [LogerProfileController::class, 'relationships'])->name('relationships.profile');
 });
 
 Route::middleware(['auth:sanctum', 'atmosphere.teamed', 'verified'])->group(function () {

--- a/tests/Feature/RouteNamesTest.php
+++ b/tests/Feature/RouteNamesTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+
+class RouteNamesTest extends TestCase
+{
+    public function test_relationship_route_names_do_not_collide(): void
+    {
+        $this->assertSame('/relationships', route('relationships.index', [], false));
+        $this->assertSame(
+            '/relationships/partner',
+            route('relationships.profile', ['profileName' => 'partner'], false)
+        );
+    }
+
+    public function test_routes_can_be_cached_without_duplicate_name_errors(): void
+    {
+        $exitCode = $this->artisan('route:cache');
+
+        $exitCode->assertSuccessful();
+
+        $this->artisan('route:clear');
+    }
+}


### PR DESCRIPTION
The LogerProfile profile-scoped page and the new RelationshipController
both registered the name `relationships.index`, which broke `route:cache`
during production builds. Rename the LogerProfile route to
`relationships.profile` (and update its sole `to_route()` caller) so the
RelationshipController keeps the canonical `relationships.index` name
alongside its `relationships.store` / `relationships.mark-as-occurred`
siblings. Adds a regression test that asserts both names resolve and
that `route:cache` succeeds.