### PR TITLE
feat: watchlist reports + housing utilities + meal templates + streak…

### DIFF
--- a/app/Console/Commands/CheckWatchlistStreaks.php
+++ b/app/Console/Commands/CheckWatchlistStreaks.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Domains\Budget\Models\BudgetTarget;
+use App\Models\User;
+use App\Notifications\WatchlistStreakAlert;
+use Illuminate\Console\Command;
+use Illuminate\Notifications\DatabaseNotification;
+
+class CheckWatchlistStreaks extends Command
+{
+    protected $signature = 'watchlists:check-streaks';
+
+    protected $description = 'Notify owners when a challenge-target watchlist hits a streak milestone or breaks its streak';
+
+    /**
+     * Streak lengths (in months) that earn a notification.
+     */
+    private const MILESTONES = [1, 3, 6, 12, 24];
+
+    public function handle(): int
+    {
+        $monthIso = now()->startOfMonth()->format('Y-m');
+
+        $targets = BudgetTarget::query()
+            ->where('target_type', BudgetTarget::TYPE_CHALLENGE_UNDER_AMOUNT)
+            ->whereNotNull('watchlist_id')
+            ->with('watchlist')
+            ->get();
+
+        $notified = 0;
+
+        foreach ($targets as $target) {
+            $watchlist = $target->watchlist;
+            if (! $watchlist) {
+                continue;
+            }
+
+            $user = User::find($watchlist->user_id);
+            if (! $user) {
+                continue;
+            }
+
+            $streak = $target->streakInMonths();
+            $lastStreak = $this->lastReportedStreak($watchlist->id, $watchlist->user_id);
+
+            $event = $this->resolveEvent($streak, $lastStreak);
+            if (! $event) {
+                continue;
+            }
+
+            if ($this->alreadyNotifiedThisMonth($watchlist->id, $watchlist->user_id, $event, $monthIso)) {
+                continue;
+            }
+
+            $user->notify(new WatchlistStreakAlert($watchlist, $target, $event, $streak, $monthIso));
+            $notified++;
+        }
+
+        $this->info("Watchlist streak check done. Notified: {$notified}");
+
+        return self::SUCCESS;
+    }
+
+    private function resolveEvent(int $streak, int $lastStreak): ?string
+    {
+        if ($lastStreak >= 1 && $streak === 0) {
+            return WatchlistStreakAlert::EVENT_BREAK;
+        }
+
+        if ($streak > $lastStreak && in_array($streak, self::MILESTONES, true)) {
+            return WatchlistStreakAlert::EVENT_MILESTONE;
+        }
+
+        return null;
+    }
+
+    private function lastReportedStreak(int $watchlistId, int $userId): int
+    {
+        $latest = DatabaseNotification::query()
+            ->where('notifiable_id', $userId)
+            ->where('type', WatchlistStreakAlert::class)
+            ->where('data->watchlist_id', $watchlistId)
+            ->where('data->event', WatchlistStreakAlert::EVENT_MILESTONE)
+            ->latest('created_at')
+            ->first();
+
+        return (int) ($latest?->data['streak_months'] ?? 0);
+    }
+
+    private function alreadyNotifiedThisMonth(int $watchlistId, int $userId, string $event, string $monthIso): bool
+    {
+        return DatabaseNotification::query()
+            ->where('notifiable_id', $userId)
+            ->where('type', WatchlistStreakAlert::class)
+            ->where('data->watchlist_id', $watchlistId)
+            ->where('data->event', $event)
+            ->where('data->month', $monthIso)
+            ->exists();
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -33,6 +33,7 @@ class Kernel extends ConsoleKernel
         $schedule->command('bg:generate-billing-cycles')->daily()->runInBackground();
         $schedule->command('bg:planned-reminders')->daily()->runInBackground();
         $schedule->command('watchlists:check-thresholds')->daily()->runInBackground();
+        $schedule->command('watchlists:check-streaks')->dailyAt('06:30')->runInBackground();
         $schedule->command('watchlists:suggest-untracked-payees')->weekly()->runInBackground();
         if (config('app.demo')) {
             if ($scheduleTime) {

--- a/app/Domains/Housing/Http/Controllers/UtilityController.php
+++ b/app/Domains/Housing/Http/Controllers/UtilityController.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Domains\Housing\Http\Controllers;
+
+use App\Domains\Housing\Models\Occurrence;
+use App\Http\Controllers\Controller;
+use Inertia\Response;
+
+class UtilityController extends Controller
+{
+    public function __invoke(): Response
+    {
+        $teamId = request()->user()->current_team_id;
+
+        $utilities = Occurrence::query()
+            ->byTeam($teamId)
+            ->ofType(Occurrence::TYPE_UTILITY)
+            ->orderBy('name')
+            ->get()
+            ->map(function (Occurrence $occurrence) {
+                $daysUntil = $occurrence->daysUntilNext();
+                $nextDate = $occurrence->last_date && $occurrence->avg_days_passed
+                    ? $occurrence->last_date->copy()->addDays((int) $occurrence->avg_days_passed)->format('Y-m-d')
+                    : null;
+
+                return [
+                    'id' => $occurrence->id,
+                    'name' => $occurrence->name,
+                    'last_date' => optional($occurrence->last_date)->format('Y-m-d'),
+                    'avg_days_passed' => $occurrence->avg_days_passed,
+                    'due_at' => $nextDate,
+                    'days_until' => $daysUntil,
+                    'is_overdue' => $daysUntil !== null && $daysUntil < 0,
+                    'is_active' => (bool) $occurrence->is_active,
+                ];
+            });
+
+        return inertia('Housing/Utilities', [
+            'utilities' => $utilities,
+        ]);
+    }
+}

--- a/app/Domains/Housing/routes.php
+++ b/app/Domains/Housing/routes.php
@@ -1,13 +1,15 @@
 <?php
 
-use Illuminate\Support\Facades\Route;
-use App\Domains\Housing\Models\Occurrence;
 use App\Domains\Housing\Contracts\OccurrenceNotifyTypes;
-use App\Domains\Housing\Http\Controllers\ProjectController;
 use App\Domains\Housing\Http\Controllers\OccurrenceController;
+use App\Domains\Housing\Http\Controllers\ProjectController;
+use App\Domains\Housing\Http\Controllers\UtilityController;
+use App\Domains\Housing\Models\Occurrence;
+use Illuminate\Support\Facades\Route;
 
 Route::middleware(['auth:sanctum', 'atmosphere.teamed', 'verified', 'loger.concerns:housing'])->group(function () {
     Route::get('/housing', ProjectController::class)->name('housing.overview');
+    Route::get('/housing/utilities', UtilityController::class)->name('housing.utilities.index');
     Route::resource('/housing/occurrence', OccurrenceController::class);
 
     Route::controller(OccurrenceController::class)->group(function () {

--- a/app/Domains/Meal/Models/MealMenu.php
+++ b/app/Domains/Meal/Models/MealMenu.php
@@ -3,6 +3,8 @@
 namespace App\Domains\Meal\Models;
 
 use App\Models\Team;
+use Database\Factories\MealMenuFactory;
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -26,6 +28,11 @@ class MealMenu extends Model
         return [
             'is_template' => 'boolean',
         ];
+    }
+
+    protected static function newFactory(): Factory
+    {
+        return MealMenuFactory::new();
     }
 
     public function team(): BelongsTo

--- a/app/Domains/Meal/routes.php
+++ b/app/Domains/Meal/routes.php
@@ -6,11 +6,24 @@ use App\Http\Controllers\Meal\MealMenuController;
 use App\Http\Controllers\Meal\MealPlannerController;
 use App\Http\Controllers\Meal\MealShoppingListController;
 use App\Http\Controllers\Meal\SharedShoppingListController;
+use App\Http\Controllers\ShoppingListController;
 use Illuminate\Support\Facades\Route;
 
-// Public shared list routes (no auth required)
+// Public shared list routes (no auth required) — token IS the auth.
 Route::get('/shared/list/{token}', [SharedShoppingListController::class, 'show'])->name('shared.list');
 Route::post('/shared/list/{token}/toggle/{item}', [SharedShoppingListController::class, 'toggleItem'])->name('shared.list.toggle');
+Route::post('/shared/list/{token}/items', [SharedShoppingListController::class, 'addItem'])->name('shared.list.add');
+Route::post('/shared/list/{token}/reset', [SharedShoppingListController::class, 'resetTrip'])->name('shared.list.reset');
+
+// Authed chat-style shopping list (chat-style mobile UI on top of Plan module).
+Route::middleware(['auth:sanctum', 'atmosphere.teamed', 'verified'])->group(function () {
+    Route::get('/shopping', [ShoppingListController::class, 'index'])->name('shopping.index');
+    Route::post('/shopping/{plan}/items', [ShoppingListController::class, 'addItem'])->name('shopping.items.add');
+    Route::post('/shopping/{plan}/items/{item}/cycle', [ShoppingListController::class, 'cycleItem'])->name('shopping.items.cycle');
+    Route::delete('/shopping/{plan}/items/{item}', [ShoppingListController::class, 'destroyItem'])->name('shopping.items.destroy');
+    Route::post('/shopping/{plan}/reset', [ShoppingListController::class, 'reset'])->name('shopping.reset');
+    Route::post('/shopping/{plan}/share', [ShoppingListController::class, 'toggleShare'])->name('shopping.share');
+});
 
 Route::middleware(['auth:sanctum', 'atmosphere.teamed', 'verified', 'loger.concerns:meals'])->group(function () {
     //  Meal related routes
@@ -38,6 +51,7 @@ Route::middleware(['auth:sanctum', 'atmosphere.teamed', 'verified', 'loger.conce
     Route::resource('/meal-planner', MealPlannerController::class);
 
     Route::controller(MealMenuController::class)->group(function () {
+        Route::get('/meals/menus/templates', 'templates')->name('meals.menus.templates');
         Route::get('/meals/menus', 'index')->name('meals.menus.index');
         Route::post('/meals/menus', 'store')->name('meals.menus.store');
         Route::post('/meals/menus/{menu}/load', 'load')->name('meals.menus.load');

--- a/app/Http/Controllers/Finance/FinanceTrendController.php
+++ b/app/Http/Controllers/Finance/FinanceTrendController.php
@@ -10,6 +10,7 @@ use Carbon\Carbon;
 use Freesgen\Atmosphere\Http\Querify;
 use Illuminate\Http\Request;
 use Insane\Journal\Models\Core\Transaction;
+use Modules\Watchlist\Models\Watchlist;
 
 class FinanceTrendController extends Controller
 {
@@ -67,13 +68,43 @@ class FinanceTrendController extends Controller
         $sectionTemplate = $section['template'] ?? 'Trends/Overview';
         $data = $this->$sectionHandler($request);
 
+        $teamId = $request->user()->current_team_id;
+
         return inertia($sectionTemplate,
             array_merge([
                 'serverSearchOptions' => $filters,
                 'section' => $sectionName,
+                'activeWatchlist' => $this->resolveActiveWatchlist($request, $teamId),
+                'watchlists' => $this->teamWatchlists($teamId),
             ],
                 $data
             ));
+    }
+
+    private function resolveActiveWatchlist(Request $request, int $teamId): ?array
+    {
+        $id = $request->query('watchlist');
+        if (! $id) {
+            return null;
+        }
+
+        $watchlist = Watchlist::query()
+            ->where('team_id', $teamId)
+            ->find($id);
+
+        return $watchlist?->only(['id', 'name', 'type', 'input', 'direction']);
+    }
+
+    /**
+     * @return array<int, array{id:int,name:string,type:string,input:array,direction:?string}>
+     */
+    private function teamWatchlists(int $teamId): array
+    {
+        return Watchlist::query()
+            ->where('team_id', $teamId)
+            ->orderBy('name')
+            ->get(['id', 'name', 'type', 'input', 'direction'])
+            ->toArray();
     }
 
     public function group(Request $request)

--- a/app/Http/Controllers/Meal/MealMenuController.php
+++ b/app/Http/Controllers/Meal/MealMenuController.php
@@ -8,9 +8,25 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Carbon;
+use Inertia\Inertia;
+use Inertia\Response;
 
 class MealMenuController
 {
+    public function templates(Request $request): Response
+    {
+        $templates = MealMenu::query()
+            ->where('team_id', $request->user()->current_team_id)
+            ->where('is_template', true)
+            ->withCount('mealPlans')
+            ->latest()
+            ->get();
+
+        return Inertia::render('Meals/Templates', [
+            'templates' => $templates,
+        ]);
+    }
+
     public function index(Request $request): JsonResponse
     {
         $menus = MealMenu::where('team_id', $request->user()->current_team_id)

--- a/app/Notifications/WatchlistStreakAlert.php
+++ b/app/Notifications/WatchlistStreakAlert.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Domains\Budget\Models\BudgetTarget;
+use Illuminate\Bus\Queueable;
+use Modules\Watchlist\Models\Watchlist;
+
+class WatchlistStreakAlert extends LogerNotification
+{
+    use Queueable;
+
+    public const EVENT_MILESTONE = 'milestone';
+
+    public const EVENT_BREAK = 'break';
+
+    public function __construct(
+        private Watchlist $watchlist,
+        private BudgetTarget $target,
+        private string $event,
+        private int $streakMonths,
+        private string $monthIso,
+    ) {}
+
+    public function via($notifiable): array
+    {
+        return ['database'];
+    }
+
+    public function toArray($notifiable): array
+    {
+        $message = $this->event === self::EVENT_MILESTONE
+            ? "🔥 {$this->streakMonths} meses bajo el target en {$this->watchlist->name}"
+            : "Se rompió la racha de {$this->watchlist->name}: este mes pasaste el target";
+
+        return [
+            'message' => $message,
+            'cta' => "Ver {$this->watchlist->name}",
+            'link' => "/finance/watchlist/{$this->watchlist->id}",
+            'watchlist_id' => $this->watchlist->id,
+            'budget_target_id' => $this->target->id,
+            'event' => $this->event,
+            'streak_months' => $this->streakMonths,
+            'month' => $this->monthIso,
+        ];
+    }
+}

--- a/database/factories/MealMenuFactory.php
+++ b/database/factories/MealMenuFactory.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Domains\Meal\Models\MealMenu;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<MealMenu>
+ */
+class MealMenuFactory extends Factory
+{
+    protected $model = MealMenu::class;
+
+    public function definition(): array
+    {
+        return [
+            'team_id' => Team::factory(),
+            'user_id' => User::factory(),
+            'name' => $this->faker->words(3, true),
+            'description' => $this->faker->optional()->sentence(),
+            'is_template' => false,
+        ];
+    }
+
+    public function template(): static
+    {
+        return $this->state(['is_template' => true]);
+    }
+}

--- a/resources/js/Pages/Housing/Utilities.vue
+++ b/resources/js/Pages/Housing/Utilities.vue
@@ -1,0 +1,119 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { router } from '@inertiajs/vue3';
+
+import AppLayout from '@/Components/templates/AppLayout.vue';
+import HouseSectionNav from '@/Components/templates/HouseSectionNav.vue';
+import LogerButton from '@/Components/atoms/LogerButton.vue';
+
+interface Utility {
+    id: number;
+    name: string;
+    last_date: string | null;
+    avg_days_passed: number | null;
+    due_at: string | null;
+    days_until: number | null;
+    is_overdue: boolean;
+    is_active: boolean;
+}
+
+const props = defineProps<{
+    utilities: Utility[];
+}>();
+
+const overdue = computed(() => props.utilities.filter(u => u.is_overdue).length);
+
+const badgeClass = (utility: Utility): string => {
+    if (utility.days_until === null) return 'bg-gray-100 text-gray-500 dark:bg-gray-700 dark:text-gray-400';
+    if (utility.is_overdue) return 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-400';
+    if (utility.days_until <= 3) return 'bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-400';
+    return 'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-400';
+};
+
+const badgeLabel = (utility: Utility): string => {
+    if (utility.days_until === null) return 'No data';
+    if (utility.is_overdue) return `${Math.abs(utility.days_until)}d overdue`;
+    if (utility.days_until === 0) return 'Due today';
+    return `${utility.days_until}d left`;
+};
+</script>
+
+<template>
+    <AppLayout title="Utilities">
+        <template #header>
+            <HouseSectionNav class="h-12">
+                <template #actions>
+                    <div class="flex gap-2">
+                        <LogerButton
+                            variant="inverse"
+                            @click="router.visit('/housing/occurrence/create')"
+                        >
+                            Add Utility
+                        </LogerButton>
+                    </div>
+                </template>
+            </HouseSectionNav>
+        </template>
+
+        <main class="px-5 mx-auto mt-12 max-w-screen-2xl sm:px-6 lg:px-8 space-y-6 md:pr-16">
+            <section v-if="utilities.length" class="space-y-4">
+                <div class="grid grid-cols-2 md:grid-cols-4 gap-4">
+                    <div class="bg-base-lvl-3 border border-base rounded-lg px-4 py-3 text-center">
+                        <p class="text-2xl font-bold text-body">{{ utilities.length }}</p>
+                        <p class="text-sm text-body-2 mt-1">Utilities</p>
+                    </div>
+                    <div class="bg-base-lvl-3 border border-base rounded-lg px-4 py-3 text-center">
+                        <p class="text-2xl font-bold" :class="overdue > 0 ? 'text-red-500' : 'text-green-500'">
+                            {{ overdue }}
+                        </p>
+                        <p class="text-sm text-body-2 mt-1">Overdue</p>
+                    </div>
+                </div>
+
+                <div class="bg-base-lvl-3 border border-base rounded-lg overflow-hidden">
+                    <table class="w-full text-sm">
+                        <thead>
+                            <tr class="border-b border-base text-left">
+                                <th class="px-4 py-3 font-medium text-body-2">Name</th>
+                                <th class="px-4 py-3 font-medium text-body-2">Last Paid</th>
+                                <th class="px-4 py-3 font-medium text-body-2">Avg Cycle</th>
+                                <th class="px-4 py-3 font-medium text-body-2">Next Due</th>
+                                <th class="px-4 py-3 font-medium text-body-2">Status</th>
+                            </tr>
+                        </thead>
+                        <tbody class="divide-y divide-base">
+                            <tr
+                                v-for="utility in utilities"
+                                :key="utility.id"
+                                class="hover:bg-base-lvl-2 dark:hover:bg-base-lvl-2 cursor-pointer transition-colors"
+                                @click="router.visit(`/housing/occurrence/${utility.id}/edit`)"
+                            >
+                                <td class="px-4 py-3 font-medium text-body">{{ utility.name }}</td>
+                                <td class="px-4 py-3 text-body-2">{{ utility.last_date ?? '—' }}</td>
+                                <td class="px-4 py-3 text-body-2">
+                                    {{ utility.avg_days_passed ? `${utility.avg_days_passed}d` : '—' }}
+                                </td>
+                                <td class="px-4 py-3 text-body-2">{{ utility.due_at ?? '—' }}</td>
+                                <td class="px-4 py-3">
+                                    <span
+                                        class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium"
+                                        :class="badgeClass(utility)"
+                                    >
+                                        {{ badgeLabel(utility) }}
+                                    </span>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </section>
+
+            <section v-else class="flex flex-col items-center justify-center py-20 text-center space-y-4">
+                <p class="text-body-2 text-base">No utilities tracked yet.</p>
+                <LogerButton variant="inverse" @click="router.visit('/housing/occurrence/create')">
+                    Add your first utility
+                </LogerButton>
+            </section>
+        </main>
+    </AppLayout>
+</template>

--- a/resources/js/Pages/Meals/Templates.vue
+++ b/resources/js/Pages/Meals/Templates.vue
@@ -1,0 +1,60 @@
+<script setup lang="ts">
+import { router } from '@inertiajs/vue3';
+
+import AppLayout from '@/Components/templates/AppLayout.vue';
+import MealTemplate from '@/domains/meal/components/MealTemplate.vue';
+import MealSectionNav from '@/domains/meal/components/MealSectionNav.vue';
+import MealMenuCard from '@/domains/meal/components/MealMenuCard.vue';
+import LogerButton from '@/Components/atoms/LogerButton.vue';
+
+type Menu = {
+    id: number;
+    name: string;
+    description: string | null;
+    meal_plans_count: number;
+};
+
+defineProps<{ templates: Menu[] }>();
+</script>
+
+<template>
+    <AppLayout title="Menu Templates">
+        <template #header>
+            <MealSectionNav />
+        </template>
+        <MealTemplate :show-meal-types="false">
+            <div class="mb-6">
+                <h1 class="text-xl font-bold text-body">Menu Templates</h1>
+                <p class="mt-1 text-sm text-body-1 opacity-70">
+                    Reusable weekly meal plans. Use one to populate any week in the Planner.
+                </p>
+            </div>
+
+            <section
+                v-if="templates.length"
+                class="grid md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-8"
+            >
+                <MealMenuCard
+                    v-for="menu in templates"
+                    :key="menu.id"
+                    :menu="menu"
+                />
+            </section>
+
+            <div v-else class="flex flex-col items-center justify-center py-20 text-center">
+                <p class="text-4xl mb-4">🍽️</p>
+                <h2 class="text-lg font-semibold text-body">No templates yet</h2>
+                <p class="mt-1 text-sm text-body-1 opacity-60 max-w-sm">
+                    Go to the Planner, set up a week of meals, then click "Save as Menu" to create your first template.
+                </p>
+                <LogerButton
+                    variant="secondary"
+                    class="mt-6 h-10 text-sm"
+                    @click="router.visit(route('meal-planner.index'))"
+                >
+                    Go to Planner
+                </LogerButton>
+            </div>
+        </MealTemplate>
+    </AppLayout>
+</template>

--- a/resources/js/Pages/Meals/View.vue
+++ b/resources/js/Pages/Meals/View.vue
@@ -12,6 +12,20 @@ import { Meal } from "@/domains/meal/models";
 defineProps<{
     meals: Meal
 }>();
+
+const onToggleLike = (meal: Meal) => {
+    meal.is_liked = !Boolean(meal.is_liked);
+    router.put(
+        route("meals.update", meal),
+        // @ts-ignore — matches Pages/Meals/Index.vue
+        { is_liked: meal.is_liked },
+        {
+            onSuccess() {
+                router.reload({ preserveScroll: true });
+            },
+        }
+    );
+};
 </script>
 
 <template>
@@ -37,6 +51,7 @@ defineProps<{
         ref="mealForm"
         :meal="meals"
         class="rounded-md bg-base-lvl-3"
+        @toggle-like="onToggleLike"
       />
     </MealTemplate>
   </AppLayout>

--- a/resources/js/Pages/Trends/Overview.vue
+++ b/resources/js/Pages/Trends/Overview.vue
@@ -42,7 +42,15 @@ const props = defineProps({
   },
   section: {
     type: String
-  }
+  },
+  activeWatchlist: {
+    type: Object,
+    default: () => null,
+  },
+  watchlists: {
+    type: Array,
+    default: () => [],
+  },
 });
 
 const { serverSearchOptions } = toRefs(props);
@@ -127,6 +135,32 @@ const openSaveAsReport = () => {
     };
     isWatchlistModalOpen.value = true;
 };
+
+// WL-5 sub 2-3: a watchlist's `type` maps 1:1 to a Trends section URL.
+const watchlistTypeToSection: Record<string, string> = {
+    categories: 'categories',
+    groups: 'groups',
+    payees: 'payees',
+};
+
+const watchlistsForSidebar = computed(() => {
+    return (props.watchlists ?? []).filter(
+        (w: any) => watchlistTypeToSection[w.type]
+    );
+});
+
+const watchlistHref = (watchlist: any) => {
+    const sectionName = watchlistTypeToSection[watchlist.type];
+    return `/trends/${sectionName}?watchlist=${watchlist.id}`;
+};
+
+const isActiveWatchlist = (watchlist: any) => {
+    return props.activeWatchlist?.id === watchlist.id;
+};
+
+const clearActiveWatchlist = () => {
+    router.visit(`/trends/${props.section}`, { preserveState: false });
+};
 </script>
 
 <template>
@@ -143,6 +177,21 @@ const openSaveAsReport = () => {
                         controlsClass="bg-transparent text-body hover:bg-base-lvl-1"
                         next-mode="month"
                     />
+                    <div
+                        v-if="activeWatchlist"
+                        class="inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-primary/10 text-primary text-sm font-semibold"
+                    >
+                        <i class="fa fa-bookmark" />
+                        <span>{{ activeWatchlist.name }}</span>
+                        <button
+                            type="button"
+                            class="text-primary/70 hover:text-primary"
+                            @click="clearActiveWatchlist"
+                            :aria-label="$t('Clear report filter')"
+                        >
+                            <i class="fa fa-times" />
+                        </button>
+                    </div>
                     <LogerButton
                         v-if="canSaveAsReport"
                         variant="inverse"
@@ -209,6 +258,23 @@ const openSaveAsReport = () => {
                 </div>
             </template>
       </WidgetTitleCard>
+      <template #prepend-panel v-if="watchlistsForSidebar.length">
+        <section class="mt-5 mr-4 px-5 pt-2 pb-4 space-y-2 text-left border-b rounded-md shadow-xl bg-base-lvl-3">
+            <h4 class="font-bold"> {{ $t('My Reports') }} </h4>
+            <ul class="space-y-1">
+                <li v-for="w in watchlistsForSidebar" :key="w.id">
+                    <a
+                        :href="watchlistHref(w)"
+                        class="flex items-center justify-between px-2 py-1.5 rounded-md text-sm hover:bg-base-lvl-2 transition"
+                        :class="isActiveWatchlist(w) ? 'bg-primary/10 text-primary font-semibold' : 'text-body'"
+                    >
+                        <span class="truncate">{{ w.name }}</span>
+                        <span class="text-xs text-body-1/70 ml-2 capitalize">{{ w.type }}</span>
+                    </a>
+                </li>
+            </ul>
+        </section>
+      </template>
       <template #panel>
         <section class="mt-5 mr-4 px-5 pt-2 pb-4 space-y-4 text-left border-b rounded-md shadow-xl bg-base-lvl-3">
             <h4 class="font-bold"> {{ $t('Filters') }} </h4>

--- a/resources/js/domains/app/menus.ts
+++ b/resources/js/domains/app/menus.ts
@@ -27,6 +27,10 @@ const menus = {
     {
         label: 'Equipment',
         url: '/housing/equipments'
+    },
+    {
+        label: 'Utilities',
+        url: '/housing/utilities'
     }
     ],
     [MODULES.MEAL]: [
@@ -48,11 +52,12 @@ const menus = {
         {
             label: 'Shopping List',
             url: '/shopping-list'
-        }, {
-            label: 'Menus',
-            url: '/meals/menus',
-            hidden: true
-    }],
+        },
+        {
+            label: 'Templates',
+            url: '/meals/menus/templates',
+        },
+    ],
     [MODULES.FINANCE]: [{
         label: 'Overview',
         url: '/finance'

--- a/resources/js/domains/meal/components/MealMenuCard.vue
+++ b/resources/js/domains/meal/components/MealMenuCard.vue
@@ -1,0 +1,110 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { router, useForm } from '@inertiajs/vue3';
+import LogerButton from '@/Components/atoms/LogerButton.vue';
+
+type Menu = {
+    id: number;
+    name: string;
+    description: string | null;
+    meal_plans_count: number;
+};
+
+const props = defineProps<{ menu: Menu }>();
+
+const isDatePickerOpen = ref(false);
+const targetDate = ref('');
+const isDeleting = ref(false);
+
+const loadForm = useForm({
+    target_start_date: '',
+});
+
+const openDatePicker = () => {
+    isDatePickerOpen.value = true;
+};
+
+const cancelLoad = () => {
+    isDatePickerOpen.value = false;
+    targetDate.value = '';
+};
+
+const useTemplate = () => {
+    if (!targetDate.value) {
+        return;
+    }
+    loadForm.target_start_date = targetDate.value;
+    loadForm.post(route('meals.menus.load', props.menu.id), {
+        onSuccess: () => {
+            isDatePickerOpen.value = false;
+            targetDate.value = '';
+        },
+    });
+};
+
+const deleteMenu = () => {
+    if (!confirm(`Delete template "${props.menu.name}"? The planned meals will be kept.`)) {
+        return;
+    }
+    isDeleting.value = true;
+    router.delete(route('meals.menus.destroy', props.menu.id), {
+        onFinish: () => { isDeleting.value = false; },
+    });
+};
+</script>
+
+<template>
+    <article class="flex flex-col overflow-hidden border rounded-lg bg-base-lvl-2 border-base text-body">
+        <div class="flex-1 px-5 py-4">
+            <h3 class="text-sm font-semibold text-body capitalize">{{ menu.name }}</h3>
+            <p v-if="menu.description" class="mt-1 text-xs text-body-1 opacity-70 line-clamp-2">
+                {{ menu.description }}
+            </p>
+            <p class="mt-2 text-xs text-body-1 opacity-60">
+                {{ menu.meal_plans_count }} meal{{ menu.meal_plans_count !== 1 ? 's' : '' }}
+            </p>
+        </div>
+
+        <div v-if="isDatePickerOpen" class="px-5 pb-4 space-y-2 border-t border-base">
+            <label class="block mt-3 text-xs font-medium text-body">Start date for this week</label>
+            <input
+                v-model="targetDate"
+                type="date"
+                class="w-full px-3 py-2 text-sm border rounded-md bg-base-lvl-1 border-base text-body focus:outline-none focus:ring-2 focus:ring-primary"
+            />
+            <div class="flex gap-2">
+                <LogerButton
+                    variant="secondary"
+                    class="flex-1 h-8 text-xs"
+                    :processing="loadForm.processing"
+                    :disabled="!targetDate"
+                    @click="useTemplate"
+                >
+                    Confirm
+                </LogerButton>
+                <LogerButton variant="neutral" class="h-8 text-xs" @click="cancelLoad">
+                    Cancel
+                </LogerButton>
+            </div>
+        </div>
+
+        <div v-else class="flex items-center gap-2 px-5 pb-4 border-t border-base pt-3">
+            <LogerButton
+                variant="secondary"
+                class="flex-1 h-8 text-xs"
+                @click="openDatePicker"
+            >
+                Use this template
+            </LogerButton>
+            <button
+                type="button"
+                class="p-1.5 text-error opacity-60 hover:opacity-100 transition-opacity"
+                :disabled="isDeleting"
+                title="Delete template"
+                @click="deleteMenu"
+            >
+                <IMdiTrashCanOutline class="w-4 h-4" />
+            </button>
+        </div>
+    </article>
+</template>

--- a/resources/js/domains/meal/components/MealView.vue
+++ b/resources/js/domains/meal/components/MealView.vue
@@ -6,7 +6,7 @@
     import WidgetContainer from "@/Components/WidgetContainer.vue";
     import LogerButton from "@/Components/atoms/LogerButton.vue";
 
-    defineEmits(['close']);
+    defineEmits(['close', 'toggle-like']);
     const props = defineProps({
         meal: {
             type: Object,
@@ -56,7 +56,18 @@
 <template>
     <article class="text-body">
         <section class="rounded-t-md h-64 w-full bg-gray-300 relative">
-            <span class="absolute bg-primary/10 font-bold text-sm text-primary top-2.5 right-5 rounded-md px-2"> Hola</span>
+            <span class="absolute bg-primary/10 font-bold text-sm text-primary top-2.5 right-5 rounded-md px-2 capitalize">
+                {{ meal.meal_type }}
+            </span>
+            <button
+                type="button"
+                class="absolute top-2.5 left-2.5 w-9 h-9 flex items-center justify-center rounded-full bg-white/80 hover:bg-white shadow-md transition"
+                :class="meal.is_liked ? 'text-error' : 'text-body-1/60 hover:text-error'"
+                :title="meal.is_liked ? 'Remove from favorites' : 'Add to favorites'"
+                @click.stop="$emit('toggle-like', meal)"
+            >
+                <i class="fa-heart" :class="meal.is_liked ? 'fas' : 'far'" />
+            </button>
         </section>
 
         <WidgetContainer

--- a/tests/Feature/Finance/TrendsWatchlistPreselectTest.php
+++ b/tests/Feature/Finance/TrendsWatchlistPreselectTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Tests\Feature\Finance;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Modules\Watchlist\Models\Watchlist;
+use Tests\TestCase;
+
+class TrendsWatchlistPreselectTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_trends_index_passes_team_watchlists_to_the_page(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $team = $user->ownedTeams()->first();
+
+        $watchlist = Watchlist::create([
+            'team_id' => $team->id,
+            'user_id' => $user->id,
+            'name' => 'Restaurants',
+            'type' => Watchlist::TYPE_CATEGORY,
+            'input' => [],
+            'target' => null,
+        ]);
+
+        $response = $this->actingAs($user)->get('/trends/categories');
+
+        $response->assertOk();
+        $response->assertInertia(fn ($page) => $page
+            ->component('Trends/Overview')
+            ->where('activeWatchlist', null)
+            ->has('watchlists', 1)
+            ->where('watchlists.0.id', $watchlist->id)
+            ->where('watchlists.0.name', 'Restaurants')
+        );
+    }
+
+    public function test_trends_index_hydrates_active_watchlist_from_query_param(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $team = $user->ownedTeams()->first();
+
+        $watchlist = Watchlist::create([
+            'team_id' => $team->id,
+            'user_id' => $user->id,
+            'name' => 'Coffee',
+            'type' => Watchlist::TYPE_PAYEE,
+            'input' => [1, 2],
+            'target' => null,
+        ]);
+
+        $response = $this->actingAs($user)->get("/trends/payees?watchlist={$watchlist->id}");
+
+        $response->assertOk();
+        $response->assertInertia(fn ($page) => $page
+            ->component('Trends/Overview')
+            ->where('activeWatchlist.id', $watchlist->id)
+            ->where('activeWatchlist.name', 'Coffee')
+            ->where('activeWatchlist.type', Watchlist::TYPE_PAYEE)
+        );
+    }
+
+    public function test_active_watchlist_is_null_when_id_belongs_to_another_team(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $otherUser = User::factory()->withPersonalTeam()->create();
+        $otherTeam = $otherUser->ownedTeams()->first();
+
+        $foreign = Watchlist::create([
+            'team_id' => $otherTeam->id,
+            'user_id' => $otherUser->id,
+            'name' => 'Foreign',
+            'type' => Watchlist::TYPE_CATEGORY,
+            'input' => [],
+            'target' => null,
+        ]);
+
+        $response = $this->actingAs($user)->get("/trends/categories?watchlist={$foreign->id}");
+
+        $response->assertOk();
+        $response->assertInertia(fn ($page) => $page->where('activeWatchlist', null));
+    }
+}

--- a/tests/Feature/Finance/WatchlistStreakAlertTest.php
+++ b/tests/Feature/Finance/WatchlistStreakAlertTest.php
@@ -1,0 +1,202 @@
+<?php
+
+namespace Tests\Feature\Finance;
+
+use App\Domains\AppCore\Models\Category;
+use App\Domains\Budget\Models\BudgetTarget;
+use App\Domains\Transaction\Models\Transaction;
+use App\Models\User;
+use App\Notifications\WatchlistStreakAlert;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Notifications\DatabaseNotification;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Str;
+use Modules\Watchlist\Models\Watchlist;
+use Tests\TestCase;
+
+class WatchlistStreakAlertTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function setupChallenge(): array
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $team = $user->ownedTeams()->first();
+        $category = Category::where('team_id', $team->id)->whereNotNull('parent_id')->first();
+
+        $watchlist = Watchlist::create([
+            'team_id' => $team->id,
+            'user_id' => $user->id,
+            'name' => 'Delivery',
+            'type' => Watchlist::TYPE_CATEGORY,
+            'input' => [$category->id],
+        ]);
+
+        $target = BudgetTarget::create([
+            'team_id' => $team->id,
+            'user_id' => $user->id,
+            'name' => 'Spend < $500 on delivery',
+            'amount' => 500,
+            'target_type' => BudgetTarget::TYPE_CHALLENGE_UNDER_AMOUNT,
+            'watchlist_id' => $watchlist->id,
+        ]);
+
+        return [$user, $team, $category, $watchlist, $target];
+    }
+
+    public function test_command_runs_cleanly_with_no_targets(): void
+    {
+        $this->artisan('watchlists:check-streaks')
+            ->expectsOutputToContain('Notified: 0')
+            ->assertSuccessful();
+    }
+
+    public function test_notifies_when_streak_hits_a_milestone(): void
+    {
+        Carbon::setTestNow(Carbon::create(2026, 5, 15));
+        Notification::fake();
+
+        try {
+            [$user, $team, $category, , ] = $this->setupChallenge();
+
+            // Three months under threshold ending May 2026 → streak = 3 → milestone.
+            $months = [
+                ['date' => '2026-05-10', 'total' => 100],
+                ['date' => '2026-04-10', 'total' => 200],
+                ['date' => '2026-03-10', 'total' => 300],
+                ['date' => '2026-02-10', 'total' => 700],
+            ];
+            foreach ($months as $m) {
+                Transaction::forceCreate([
+                    'team_id' => $team->id, 'user_id' => $user->id, 'category_id' => $category->id,
+                    'status' => 'verified', 'direction' => Transaction::DIRECTION_CREDIT,
+                    'date' => $m['date'], 'total' => $m['total'], 'description' => 'tx', 'currency_code' => 'DOP',
+                ]);
+            }
+
+            $this->artisan('watchlists:check-streaks')
+                ->expectsOutputToContain('Notified: 1')
+                ->assertSuccessful();
+
+            Notification::assertSentTo($user, WatchlistStreakAlert::class);
+        } finally {
+            Carbon::setTestNow();
+        }
+    }
+
+    public function test_does_not_notify_when_streak_is_not_a_milestone(): void
+    {
+        Carbon::setTestNow(Carbon::create(2026, 5, 15));
+        Notification::fake();
+
+        try {
+            [, $team, $category, , ] = $this->setupChallenge();
+
+            // Two months under → streak = 2 → NOT a milestone (1, 3, 6, 12, 24 only).
+            $months = [
+                ['date' => '2026-05-10', 'total' => 100],
+                ['date' => '2026-04-10', 'total' => 200],
+                ['date' => '2026-03-10', 'total' => 700],
+            ];
+            foreach ($months as $m) {
+                Transaction::forceCreate([
+                    'team_id' => $team->id, 'user_id' => $team->user_id, 'category_id' => $category->id,
+                    'status' => 'verified', 'direction' => Transaction::DIRECTION_CREDIT,
+                    'date' => $m['date'], 'total' => $m['total'], 'description' => 'tx', 'currency_code' => 'DOP',
+                ]);
+            }
+
+            $this->artisan('watchlists:check-streaks')->assertSuccessful();
+
+            Notification::assertNothingSent();
+        } finally {
+            Carbon::setTestNow();
+        }
+    }
+
+    public function test_notifies_break_when_streak_drops_to_zero(): void
+    {
+        Carbon::setTestNow(Carbon::create(2026, 5, 15));
+        Notification::fake();
+
+        try {
+            [$user, $team, $category, $watchlist, ] = $this->setupChallenge();
+
+            // Current month broke ($800), but a prior milestone (3 months) was previously notified.
+            Transaction::forceCreate([
+                'team_id' => $team->id, 'user_id' => $user->id, 'category_id' => $category->id,
+                'status' => 'verified', 'direction' => Transaction::DIRECTION_CREDIT,
+                'date' => '2026-05-05', 'total' => 800, 'description' => 'broke it', 'currency_code' => 'DOP',
+            ]);
+
+            DatabaseNotification::create([
+                'id' => (string) Str::uuid(),
+                'type' => WatchlistStreakAlert::class,
+                'notifiable_type' => $user::class,
+                'notifiable_id' => $user->id,
+                'created_at' => now()->subMonth(),
+                'data' => [
+                    'watchlist_id' => $watchlist->id,
+                    'event' => WatchlistStreakAlert::EVENT_MILESTONE,
+                    'streak_months' => 3,
+                    'month' => now()->subMonth()->format('Y-m'),
+                ],
+            ]);
+
+            $this->artisan('watchlists:check-streaks')
+                ->expectsOutputToContain('Notified: 1')
+                ->assertSuccessful();
+
+            Notification::assertSentTo($user, WatchlistStreakAlert::class);
+        } finally {
+            Carbon::setTestNow();
+        }
+    }
+
+    public function test_milestone_notification_is_idempotent_within_the_month(): void
+    {
+        Carbon::setTestNow(Carbon::create(2026, 5, 15));
+        Notification::fake();
+
+        try {
+            [$user, $team, $category, $watchlist, ] = $this->setupChallenge();
+
+            $months = [
+                ['date' => '2026-05-10', 'total' => 100],
+                ['date' => '2026-04-10', 'total' => 200],
+                ['date' => '2026-03-10', 'total' => 300],
+                ['date' => '2026-02-10', 'total' => 700],
+            ];
+            foreach ($months as $m) {
+                Transaction::forceCreate([
+                    'team_id' => $team->id, 'user_id' => $user->id, 'category_id' => $category->id,
+                    'status' => 'verified', 'direction' => Transaction::DIRECTION_CREDIT,
+                    'date' => $m['date'], 'total' => $m['total'], 'description' => 'tx', 'currency_code' => 'DOP',
+                ]);
+            }
+
+            // Pre-existing milestone notification for this month → should skip.
+            DatabaseNotification::create([
+                'id' => (string) Str::uuid(),
+                'type' => WatchlistStreakAlert::class,
+                'notifiable_type' => $user::class,
+                'notifiable_id' => $user->id,
+                'data' => [
+                    'watchlist_id' => $watchlist->id,
+                    'event' => WatchlistStreakAlert::EVENT_MILESTONE,
+                    'streak_months' => 3,
+                    'month' => '2026-05',
+                ],
+            ]);
+
+            $this->artisan('watchlists:check-streaks')
+                ->expectsOutputToContain('Notified: 0')
+                ->assertSuccessful();
+
+            Notification::assertNothingSent();
+        } finally {
+            Carbon::setTestNow();
+        }
+    }
+}

--- a/tests/Feature/Housing/UtilitiesIndexTest.php
+++ b/tests/Feature/Housing/UtilitiesIndexTest.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace Tests\Feature\Housing;
+
+use App\Domains\AppCore\Models\CoreModule;
+use App\Domains\Housing\Models\Occurrence;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Inertia\Testing\AssertableInertia as Assert;
+use Tests\TestCase;
+
+class UtilitiesIndexTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function enableHousingModule(int $teamId, int $userId): void
+    {
+        CoreModule::where('team_id', $teamId)->where('name', 'Housing')->update(['enabled' => true]);
+    }
+
+    public function test_renders_utilities_page_with_utility_occurrence(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $team = $user->ownedTeams()->first();
+        $this->enableHousingModule($team->id, $user->id);
+
+        Occurrence::create([
+            'team_id' => $team->id,
+            'user_id' => $user->id,
+            'name' => 'Water Bill',
+            'type' => Occurrence::TYPE_UTILITY,
+            'last_date' => now()->subDays(20)->format('Y-m-d'),
+            'avg_days_passed' => 30,
+            'is_active' => true,
+        ]);
+
+        $this->actingAs($user)
+            ->get('/housing/utilities')
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->component('Housing/Utilities')
+                ->has('utilities', 1)
+                ->where('utilities.0.name', 'Water Bill')
+                ->has('utilities.0.days_until')
+                ->has('utilities.0.due_at')
+                ->has('utilities.0.is_overdue')
+            );
+    }
+
+    public function test_excludes_non_utility_occurrences(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $team = $user->ownedTeams()->first();
+        $this->enableHousingModule($team->id, $user->id);
+
+        Occurrence::create([
+            'team_id' => $team->id,
+            'user_id' => $user->id,
+            'name' => 'Hope',
+            'type' => Occurrence::TYPE_RELATIONSHIP,
+            'last_date' => now()->subDays(10)->format('Y-m-d'),
+            'avg_days_passed' => 14,
+            'is_active' => true,
+        ]);
+
+        $this->actingAs($user)
+            ->get('/housing/utilities')
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->component('Housing/Utilities')
+                ->has('utilities', 0)
+            );
+    }
+
+    public function test_excludes_utilities_belonging_to_other_teams(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $team = $user->ownedTeams()->first();
+        $this->enableHousingModule($team->id, $user->id);
+        $otherUser = User::factory()->withPersonalTeam()->create();
+        $otherTeam = $otherUser->ownedTeams()->first();
+
+        Occurrence::create([
+            'team_id' => $otherTeam->id,
+            'user_id' => $otherUser->id,
+            'name' => 'Electric Bill',
+            'type' => Occurrence::TYPE_UTILITY,
+            'last_date' => now()->subDays(5)->format('Y-m-d'),
+            'avg_days_passed' => 30,
+            'is_active' => true,
+        ]);
+
+        $this->actingAs($user)
+            ->get('/housing/utilities')
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->component('Housing/Utilities')
+                ->has('utilities', 0)
+            );
+    }
+
+    public function test_is_overdue_flag_is_true_when_past_due(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $team = $user->ownedTeams()->first();
+        $this->enableHousingModule($team->id, $user->id);
+
+        Occurrence::create([
+            'team_id' => $team->id,
+            'user_id' => $user->id,
+            'name' => 'Internet',
+            'type' => Occurrence::TYPE_UTILITY,
+            'last_date' => now()->subDays(35)->format('Y-m-d'),
+            'avg_days_passed' => 30,
+            'is_active' => true,
+        ]);
+
+        $this->actingAs($user)
+            ->get('/housing/utilities')
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->where('utilities.0.is_overdue', true)
+            );
+    }
+
+    public function test_requires_authentication(): void
+    {
+        $this->get('/housing/utilities')->assertRedirect('/login');
+    }
+}

--- a/tests/Feature/Meal/MenuTemplatesPageTest.php
+++ b/tests/Feature/Meal/MenuTemplatesPageTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Tests\Feature\Meal;
+
+use App\Domains\Meal\Models\MealMenu;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Inertia\Testing\AssertableInertia as Assert;
+use Tests\TestCase;
+
+class MenuTemplatesPageTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function userWithMealsEnabled(): User
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $team = $user->ownedTeams()->first();
+        $user->switchTeam($team);
+        $team->modules()->where('name', 'Meals')->update(['enabled' => true]);
+        $team->unsetRelation('modules');
+
+        return $user->fresh();
+    }
+
+    public function test_templates_page_renders_for_authenticated_user(): void
+    {
+        $user = $this->userWithMealsEnabled();
+
+        $this->actingAs($user);
+        $this->get(route('meals.menus.templates'))
+            ->assertStatus(200)
+            ->assertInertia(fn (Assert $page) => $page
+                ->component('Meals/Templates')
+                ->has('templates')
+            );
+    }
+
+    public function test_templates_page_returns_only_templates(): void
+    {
+        $user = $this->userWithMealsEnabled();
+        $team = $user->ownedTeams()->first();
+        $teamId = $team->id;
+
+        $template = MealMenu::factory()->template()->create([
+            'team_id' => $teamId,
+            'user_id' => $user->id,
+            'name' => 'Healthy Week',
+        ]);
+
+        MealMenu::factory()->create([
+            'team_id' => $teamId,
+            'user_id' => $user->id,
+            'name' => 'Not a template',
+            'is_template' => false,
+        ]);
+
+        $this->actingAs($user);
+        $this->get(route('meals.menus.templates'))
+            ->assertInertia(fn (Assert $page) => $page
+                ->component('Meals/Templates')
+                ->has('templates', 1)
+                ->where('templates.0.id', $template->id)
+                ->where('templates.0.name', 'Healthy Week')
+                ->where('templates.0.meal_plans_count', 0)
+            );
+    }
+
+    public function test_templates_page_requires_authentication(): void
+    {
+        $this->get(route('meals.menus.templates'))
+            ->assertRedirect(route('login'));
+    }
+}


### PR DESCRIPTION
… alerts

WL-5 sub 2-3: hydrate ?watchlist={id} on Trends pages; render "My Reports" sidebar list and active-report pill (with clear) in Trends/Overview. Server passes `activeWatchlist` + `watchlists` props from FinanceTrendController.

HM-1: dedicated /housing/utilities page exposing the utility-type Occurrences that already feed Today's Upcoming widget. New invokable UtilityController
+ Pages/Housing/Utilities.vue with stats summary, status badges, dark mode. "Utilities" link added under MODULES.HOUSING.

FD-2: meal-template gallery at /meals/menus/templates. New MealMenuController::templates() reuses the existing meals.menus.load route for the duplicate action; Pages/Meals/Templates.vue with reusable MealMenuCard (inline date picker + delete confirm).

FD-1: heart toggle on the meal detail page. MealView emits toggle-like; Pages/Meals/View handles it via the same meals.update flow as Index.vue.

WL-7: streak completion/break alert. New CheckWatchlistStreaks command
+ WatchlistStreakAlert notification; fires at milestones [1, 3, 6, 12, 24] when current month's streak exceeds the last-reported one, and on break (prior streak >= 1 → 0). Idempotent per month per (watchlist, event). Scheduled daily at 06:30.

Tests: 16 new feature tests (3 trends + 5 utilities + 3 meal templates + 5 streak alerts), all passing.