### PR TITLE
fix: mobile transaction views layout

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -16,6 +16,11 @@
 
 .aside-content {
     width: -webkit-fill-available;
-    height: 100%;
-    overflow: auto;
+}
+
+@media (min-width: 768px) {
+    .aside-content {
+        height: 100%;
+        overflow: auto;
+    }
 }

--- a/resources/js/Components/molecules/TransactionCard.vue
+++ b/resources/js/Components/molecules/TransactionCard.vue
@@ -85,6 +85,10 @@ const isDateInPast = computed(() => {
     return props.date ? isBefore(parseISO(props.date), new Date()) : false
 })
 
+const hasMeta = computed(() => {
+    return Boolean(props.date || props.subtitle || props.valueSubtitle);
+})
+
 const handleOptions = (option: 'remove'|'selected') => {
   emit(option);
 };
@@ -101,44 +105,61 @@ const handleOptions = (option: 'remove'|'selected') => {
         : 'odd:bg-base-lvl-2 even:bg-base-lvl-1',
     ]"
   >
-    <div class="flex justify-between px-5 py-2 space-x-2">
-      <div class="flex w-6/12 space-x-3 truncate">
-        <div v-if="allowSelect" class="flex items-center h-full">
-          <input type="checkbox" :checked="isSelected" @click="handleSelect" />
-        </div>
-        <div>
-          <h4 class="font-bold truncate">{{ title }}</h4>
-          <small class="text-sm"> {{ subtitle }}</small>
-        </div>
+    <div class="flex items-start gap-2 px-3 py-2.5 sm:px-5 sm:gap-3">
+      <div v-if="allowSelect" class="flex items-center pt-0.5 shrink-0">
+        <input type="checkbox" :checked="isSelected" @click="handleSelect" />
       </div>
-      <div class="flex space-x-5">
-        <div class="text-right">
-          <h4 class="relative font-bold">
-            <NumberHider />
-            {{ formatMoney(value, currencyCode) }}
-            <span v-if="expenses" class="text-red-500"
-              >({{ formatMoney(expenses, currencyCode) }})</span
-            >
+      <div class="flex-1 min-w-0">
+        <div class="flex items-start justify-between gap-2">
+          <h4 class="text-sm font-bold leading-snug break-words sm:text-base text-body flex-1 min-w-0">
+            {{ title }}
           </h4>
-          <small class="block text-sm" :class="[isDateInPast ? 'text-error font-bold': 'text-secondary']">
-            {{ date ? formatDate(date) : valueSubtitle }}
-        </small>
+          <div class="text-right shrink-0 tabular-nums">
+            <h4 class="relative text-sm font-bold leading-snug sm:text-base">
+              <NumberHider />
+              {{ formatMoney(value, currencyCode) }}
+            </h4>
+            <span v-if="expenses" class="block text-xs text-red-500">
+              ({{ formatMoney(expenses, currencyCode) }})
+            </span>
+          </div>
         </div>
-        <NDropdown
-            v-if="hasOptions"
-            trigger="click"
-            key-field="name"
-            :options="options"
-            :on-select="handleOptions"
-            @click.stop
+        <div
+          v-if="hasMeta"
+          class="mt-1 flex flex-wrap items-center gap-x-1.5 gap-y-0.5 text-xs text-body-1/70 normal-case"
         >
-          <button class="px-2 hover:bg-base-lvl-3">
-            <IMdiEllipsisVertical />
-          </button>
-        </NDropdown>
+          <span
+            v-if="date"
+            class="whitespace-nowrap"
+            :class="[isDateInPast ? 'text-error font-semibold' : 'text-secondary']"
+          >
+            {{ formatDate(date) }}
+          </span>
+          <span v-if="date && (subtitle || valueSubtitle)" class="text-body-1/30">·</span>
+          <span v-if="!date && valueSubtitle" class="whitespace-nowrap text-secondary">
+            {{ valueSubtitle }}
+          </span>
+          <template v-else-if="valueSubtitle">
+            <span class="truncate text-body-1/80">{{ valueSubtitle }}</span>
+            <span v-if="subtitle" class="text-body-1/30">·</span>
+          </template>
+          <span v-if="subtitle" class="min-w-0 truncate">{{ subtitle }}</span>
+        </div>
       </div>
+      <NDropdown
+          v-if="hasOptions"
+          trigger="click"
+          key-field="name"
+          :options="options"
+          :on-select="handleOptions"
+          @click.stop
+      >
+        <button class="shrink-0 px-1.5 py-1 -mr-1 rounded text-body-1/60 hover:text-body hover:bg-base-lvl-3">
+          <IMdiEllipsisVertical />
+        </button>
+      </NDropdown>
     </div>
-    <div class="px-5" v-if="expenses">
+    <div class="px-5 pb-1" v-if="expenses">
       <NProgress
         :percentage="percentage"
         :stroke-width="1"

--- a/resources/js/Pages/Finance/Account.vue
+++ b/resources/js/Pages/Finance/Account.vue
@@ -518,10 +518,10 @@ const selectedTabName = computed(() => {
                 </template>
             </WidgetContainer>
 
-            <template #prepend-panel class="">
+            <template #prepend-panel>
                 <section
                     v-if="isCreditCard"
-                    class="w-full px-4 pt-4">
+                    class="w-full pt-4">
                     <div class="rounded-lg bg-base-lvl-3 px-4 py-3">
                         <header class="flex items-center justify-between text-xs text-body-1/70">
                             <span>{{ $t('Last payment') }}</span>
@@ -530,7 +530,7 @@ const selectedTabName = computed(() => {
                                 {{ $t('Not linked to a cycle') }}
                             </span>
                         </header>
-                        <div v-if="lastCreditCardPayment" class="mt-1 flex items-baseline justify-between gap-3">
+                        <div v-if="lastCreditCardPayment" class="mt-1 flex items-baseline justify-between gap-3 flex-wrap">
                             <span class="text-lg font-semibold text-body">
                                 {{ formatMoney(lastCreditCardPayment.amount, selectedAccount?.currency_code) }}
                             </span>
@@ -546,7 +546,7 @@ const selectedTabName = computed(() => {
                         </p>
                     </div>
                 </section>
-                <NextPaymentsWidget class="w-full py-4 px-4" :title="$t('Credit Card Payments')" :payments="billingCycles.map((payment) => ({
+                <NextPaymentsWidget class="w-full" :title="$t('Credit Card Payments')" :payments="billingCycles.map((payment) => ({
                     ...payment,
                     date: payment.due_at
                 }))" emit-actions emit-delete @action="setPaymentBill">

--- a/resources/js/Pages/Finance/Partials/FinanceTemplate.vue
+++ b/resources/js/Pages/Finance/Partials/FinanceTemplate.vue
@@ -57,23 +57,23 @@
 </script>
 
 <template>
-    <article class="px-5 mx-auto mt-12 space-y-10 md:space-y-0 md:space-x-10  relative md:flex max-w-screen-2xl sm:px-6 lg:px-8">
+    <article class="px-3 sm:px-5 mx-auto mt-12 space-y-6 md:space-y-0 md:space-x-10  relative md:flex max-w-screen-2xl sm:px-6 lg:px-8">
         <main
-            class="md:w-9/12 overflow-hidden md:pr-5  md:pl-8"
+            class="overflow-hidden md:w-9/12 md:pr-5 md:pl-8"
             :class="!hidePanel && 'md:w-6/12 lg:w-7/12 xl:w-8/12 2xl:w-10/12'"
         >
             <slot name="prepend-panel" v-if="hidePanel" />
             <slot />
         </main>
 
-        <aside class="space-y-4 md:w-3/12 bg-blue sticky top-0" v-if="!hidePanel">
-            <section class="px-2 w-full aside-content">
+        <aside class="space-y-4 md:w-3/12 md:sticky md:top-0" v-if="!hidePanel">
+            <section class="w-full md:px-2 aside-content">
                 <slot name="prepend-panel" />
                 <slot name="panel">
                     <AccountsLedger
                         :accounts="accounts"
                         :class="[cardShadow]"
-                        class="px-4 py-2 w-full space-y-4 cursor-pointer md:mt-4 rounded-b-md md:rounded-md min-h-min bg-base-lvl-3"
+                        class="px-4 py-2 w-full space-y-4 cursor-pointer md:mt-4 rounded-md min-h-min bg-base-lvl-3"
                         @reordered="saveReorder"
                     />
                 </slot>

--- a/resources/js/domains/transactions/components/NextPaymentsWidget.vue
+++ b/resources/js/domains/transactions/components/NextPaymentsWidget.vue
@@ -44,11 +44,11 @@ const handleRemove = (transaction: ITransaction) => {
 
 <template>
 <div
-    class="mt-4 mb-4 overflow-hidden bg-white sm:rounded-lg"
+    class="mt-4 mb-4 overflow-hidden rounded-lg bg-base-lvl-3"
     :class="cardShadow"
 >
-    <h4 v-if="!hideTitle" class="pb-2 font-bold">{{ resolvedTitle }}</h4>
-    <section class="space-y-2" v-if="payments?.length">
+    <h4 v-if="!hideTitle" class="px-4 pt-3 pb-2 font-bold">{{ resolvedTitle }}</h4>
+    <section class="space-y-2 pb-2" v-if="payments?.length">
         <NextPaymentItem
             v-for="transaction in payments"
             :key="transaction.id"

--- a/resources/js/domains/transactions/formatters.ts
+++ b/resources/js/domains/transactions/formatters.ts
@@ -36,6 +36,7 @@ export const draftsDBToTransaction = (transactions: any[]) => {
 export const fromDBToAllAccounts = (transactions) => {
     return transactions.map(transaction => ({
         id: transaction.id || v4(),
+        date: transaction.date,
         title: transaction.description,
         subtitle: transaction.category?.name,
         value: transaction.total,


### PR DESCRIPTION
## Summary
- Rebuilt TransactionCard as two-line stacked card: description + amount on top, date/category/account on second line
- - Fixed all-transactions list missing date field (parser was dropping it)
- - Fixed account detail side panel overflow on mobile (Last payment, Credit Card Payments sections)
- - Fixed dark mode issue on NextPaymentsWidget
- - Tightened padding and removed sticky scroll-pane on mobile for proper stacking
## Test plan
- [ ] Open All Transactions on mobile - verify rows show date, description, amount, category
- [ ] - [ ] Open an account detail page on mobile - verify Last Payment and Credit Card Payments don't overflow
- [ ] - [ ] Check dark mode on account detail page