### PR TITLE
fix(EventServiceProvider): restore file truncated mid-string

### DIFF
--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -2,9 +2,9 @@
 
 namespace App\Providers;
 
+use App\Domains\Transaction\Listeners\AutoLinkCreditCardPayment;
 use App\Domains\Transaction\Listeners\DeleteTransactionPayment;
 use App\Domains\Transaction\Listeners\UpdateOpenReconciliations;
-use App\Domains\Transaction\Listeners\AutoLinkCreditCardPayment;
 use App\Domains\Transaction\Listeners\UpdatePlannedTransactions;
 use App\Events\AutomationEvent;
 use App\Events\BudgetAssigned;
@@ -101,4 +101,15 @@ class EventServiceProvider extends ServiceProvider
             CreateOccurrenceAutomation::class,
         ],
         ShoppingListItemUpdated::class => [
-            PushShoppingList
+            PushShoppingListUpdate::class,
+        ],
+    ];
+
+    /**
+     * Register any events for your application.
+     */
+    public function boot(): void
+    {
+        //
+    }
+}


### PR DESCRIPTION
The previous commit (fd5e7858) accidentally landed a truncated copy of EventServiceProvider.php — the file ended mid-class at 'PushShoppingList' (missing 'Update::class,', the closing brackets for the $listen array, and the closing brace of the class).

This caused composer's post-autoload-dump 'php artisan package:discover' to fail with:
  PHP Parse error: Unclosed '[' on line 103
  Script @php artisan package:discover --ansi ... returned with error code 1

Deploys (coolify build) were aborting at the autoload step.

Sandbox file-tool edits hit an intermittent truncation issue tied to OneDrive sync between the Windows file path and the Linux mount view. Re-written through a direct shell heredoc to bypass it.