### PR TITLE
fix(BillingCycle): restore file truncated mid-string

### DIFF
--- a/app/Domains/Transaction/Models/BillingCycle.php
+++ b/app/Domains/Transaction/Models/BillingCycle.php
@@ -225,4 +225,57 @@ class BillingCycle extends Model implements IPayableDocument
             'client_id' => $transaction->user_id,
             'currency_code' => $transaction->currency_code,
             'currency_rate' => $transaction->currency_rate,
-            'status' =>
+            'status' => 'verified',
+            'transaction_id' => $transaction->id,
+        ]);
+
+        $transaction->update([
+            'transactionable_type' => Payment::class,
+            'transactionable_id' => $payment->id,
+        ]);
+
+        $this->save();
+
+        return $payment;
+    }
+
+    public function createPayment($formData)
+    {
+        $paid = $this->payments->sum('amount');
+        if ($paid >= $this->total) {
+            throw new Exception('This invoice is already paid');
+        }
+
+        $debt = $this->total - $paid;
+
+        $formData['amount'] = $formData['amount'] > $debt ? $debt : $formData['amount'];
+        $payment = $this->payments()->create([
+            ...$formData,
+            'user_id' => $formData['user_id'] ?? $this->user_id,
+            'team_id' => $formData['team_id'] ?? $this->team_id,
+            'client_id' => $formData['client_id'] ?? $this->user_id,
+        ]);
+
+        $this->save();
+
+        return $payment;
+    }
+
+    public function createPaymentTransaction(Payment $payment)
+    {
+        $direction = Transaction::DIRECTION_CREDIT;
+        $counterAccountId = $this->account_id;
+
+        return [
+            'team_id' => $payment->team_id,
+            'user_id' => $payment->user_id,
+            'date' => $payment->payment_date,
+            'description' => $payment->concept,
+            'direction' => $direction,
+            'total' => $payment->amount,
+            'account_id' => $payment->account_id,
+            'counter_account_id' => $counterAccountId,
+            'items' => [],
+        ];
+    }
+}


### PR DESCRIPTION
Same file-tool truncation bug as EventServiceProvider (ce9bf515) — the committed version of BillingCycle.php in fd5e7858 ended mid-string at line 227 'status' =>, leaving the [ from $payments->create([ on line 217 unclosed. This caused PHP ParseError 'Unclosed [ on line 217' at deploy.

Local file (281 lines) was complete and parseable; the previous commit picked up an intermediate truncated state from a Windows/OneDrive sync race. Re-committing the full content.